### PR TITLE
 added psutil requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 requests
 bitshares>=0.1.12
 uptick
+psutil==5.4.8


### PR DESCRIPTION
requirement needed for installation. Tested and runs on OSX 10.13.6